### PR TITLE
Add '--display-*' cli-args for formatted url modification

### DIFF
--- a/geos/scripts/runserver.py
+++ b/geos/scripts/runserver.py
@@ -26,10 +26,23 @@ def run_app(default_host=app.config['HOST'], default_port=app.config['PORT']):
     argp.add_argument("-P", "--port", required=False,
                       help="Port for the Flask app [default {}]".format(default_port),
                       default=default_port)
+    argp.add_argument("--display-host", required=False,
+                      help="Hostname used for self-referencing links [defaults to Flask hostname]",
+                      default=None)
+    argp.add_argument("--display-port", required=False,
+                      help="Port used for self-referencing links [defaults to Flask port]",
+                      default=None)
+    argp.add_argument("--display-scheme", required=False,
+                      help="URI-scheme used for self-referencing links [default {}]".format(app.config["PREFERRED_URL_SCHEME"]),
+                      default=None)
 
     args = argp.parse_args()
 
-    app.config['url_formatter'] = URLFormatter(args.host, args.port, app.config["PREFERRED_URL_SCHEME"])
+    app.config['url_formatter'] = URLFormatter(
+        host=args.display_host if args.display_host else args.host,
+        port=args.display_port if args.display_port else args.port,
+        url_scheme=args.display_scheme if args.display_scheme else app.config["PREFERRED_URL_SCHEME"]
+    )
     app.config['mapsources'] = geos.mapsource.load_maps(MAPSOURCES)
     if args.mapsource is not None:
         app.config["mapsources"].update(geos.mapsource.load_maps(args.mapsource))


### PR DESCRIPTION
 (useful behind a reverse-proxy)

Example:
```
     +-----------------------------------------+     +-----------------------------+
---->| reverse-proxy: https://geos.example.org |<--->| geos: http://localhost:5000 |
     +-----------------------------------------+     +-----------------------------+
```

Then, one could run `geos` by executing:
```bash
$ geos --host 127.0.0.1 --port 5000 --display-host geos.example.org  --display-port 443 --display-scheme https
```

Now `kml-master.kml` reads:
```xml
<?xml version='1.0' encoding='ASCII'?>
<kml xmlns:atom="http://www.w3.org/2005/Atom" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns="http://www.opengis.net/kml/2.2">
  <Document>
    <NetworkLink>
      <name>OSM Mapnik (default)</name>
      <visibility>0</visibility>
      <Link>
        <href>https://geos.example.org:443/maps/default.kml</href>
        <viewRefreshMode>onRegion</viewRefreshMode>
      </Link>
    </NetworkLink>
    <NetworkLink>
      [...]
    </NetworkLink>
  </Document>
</kml>
```