### PR TITLE
Avoid CORS blocking

### DIFF
--- a/geos/static/custom.js
+++ b/geos/static/custom.js
@@ -314,7 +314,7 @@ function activateMap(mapSource) {
         tmpLayer = new ol.layer.Tile({
             source: new ol.source.XYZ({
                 url: tileLayer.tile_url,
-                crossOrigin: 'anonymous',
+                crossOrigin: null,
                 minZoom: tileLayer.min_zoom,
                 maxZoom: tileLayer.max_zoom
             })


### PR DESCRIPTION
change crossOrigin from 'anonymous' to null (see https://help.openstreetmap.org/questions/38308/osm-tile-server-how-to-enable-cors)

Closes #25 