### PR TITLE
Support serverParts in customMapSource

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,0 +1,34 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[test]
+      - name: Test with pytest
+        run: |
+          cd geos && pytest --doctest-modules .
+      - name: Test CLI
+        run: |
+          geos -h

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Byte-compiled / optimized / DLL files
+*.code-workspace
 __pycache__/
 *.py[cod]
 *$py.class

--- a/geos/mapsource.py
+++ b/geos/mapsource.py
@@ -129,7 +129,7 @@ class MapLayer(object):
     @property
     def get_tile_urls(self):
         if(len(self.server_parts) == 0):
-            return self.tile_url.replace("$", "")
+            return [self.tile_url.replace("$", "")]
         else:
             cur_tile_url = []
             for s in self.server_parts:

--- a/geos/mapsource.py
+++ b/geos/mapsource.py
@@ -116,7 +116,7 @@ class MapLayer(object):
         Fill the placeholders of the tile url with zoom, x and y.
 
         >>> ms = MapSource.from_xml("mapsources/osm.xml")
-        >>> ms.get_tile_url(42, 43, 44)
+        >>> ms.layers[0].get_tile_url(42, 43, 44)
         'http://tile.openstreetmap.org/42/43/44.png'
         """
         return self.tile_url.format(**{"$z": zoom, "$x": x, "$y": y})
@@ -143,7 +143,7 @@ class MapSource(object):
 
         >>> ms = MapSource.from_xml("mapsources/osm.xml")
         >>> ms.name
-        'OSM Mapnik'
+        'OSM Mapnik (default)'
         >>> ms.min_zoom
         0
         >>> ms.max_zoom

--- a/geos/mapsource.py
+++ b/geos/mapsource.py
@@ -4,6 +4,7 @@ import os
 from pprint import pprint
 from geos.geometry import GeographicBB
 import re
+import random
 
 F_SEP = "/"  # folder separator in mapsources (not necessarily == os.sep)
 
@@ -110,6 +111,7 @@ class MapLayer(object):
         self.tile_url = tile_url
         self.min_zoom = min_zoom
         self.max_zoom = max_zoom
+        self.server_parts = []
 
     def get_tile_url(self, zoom, x, y):
         """
@@ -119,8 +121,21 @@ class MapLayer(object):
         >>> ms.get_tile_url(42, 43, 44)
         'http://tile.openstreetmap.org/42/43/44.png'
         """
-        return self.tile_url.format(**{"$z": zoom, "$x": x, "$y": y})
+        if(len(self.server_parts) == 0):
+            return self.tile_url.format(**{"$z": zoom, "$x": x, "$y": y})
+        else:
+            return self.tile_url.format(**{"$z": zoom, "$x": x, "$y": y, "$serverpart": random.choice(self.server_parts)})
 
+    @property
+    def get_tile_urls(self):
+        if(len(self.server_parts) == 0):
+            return self.tile_url.replace("$", "")
+        else:
+            cur_tile_url = []
+            for s in self.server_parts:
+                cur_tile_url.append(self.tile_url.replace("{$serverpart}", s).replace("$", ""))
+        return cur_tile_url
+        
     def __repr__(self):
         return "<MapLayer: url:{}, min_zoom:{}, max_zoom:{}>".format(
             self.tile_url, self.min_zoom, self.max_zoom)
@@ -247,6 +262,8 @@ class MapSource(object):
                     map_layer.min_zoom = int(elem.text)
                 elif elem.tag == 'maxZoom':
                     map_layer.max_zoom = int(elem.text)
+                elif elem.tag == 'serverParts':
+                    map_layer.server_parts += str(elem.text).split()
         except ValueError:
             raise MapSourceException("minZoom/maxZoom must be an integer. ")
 

--- a/geos/mapsource.py
+++ b/geos/mapsource.py
@@ -4,6 +4,7 @@ import os
 from pprint import pprint
 from geos.geometry import GeographicBB
 import re
+import random
 
 F_SEP = "/"  # folder separator in mapsources (not necessarily == os.sep)
 
@@ -110,6 +111,7 @@ class MapLayer(object):
         self.tile_url = tile_url
         self.min_zoom = min_zoom
         self.max_zoom = max_zoom
+        self.server_parts = []
 
     def get_tile_url(self, zoom, x, y):
         """
@@ -119,8 +121,21 @@ class MapLayer(object):
         >>> ms.layers[0].get_tile_url(42, 43, 44)
         'http://tile.openstreetmap.org/42/43/44.png'
         """
-        return self.tile_url.format(**{"$z": zoom, "$x": x, "$y": y})
+        if(len(self.server_parts) == 0):
+            return self.tile_url.format(**{"$z": zoom, "$x": x, "$y": y})
+        else:
+            return self.tile_url.format(**{"$z": zoom, "$x": x, "$y": y, "$serverpart": random.choice(self.server_parts)})
 
+    @property
+    def get_tile_urls(self):
+        if(len(self.server_parts) == 0):
+            return self.tile_url.replace("$", "")
+        else:
+            cur_tile_url = []
+            for s in self.server_parts:
+                cur_tile_url.append(self.tile_url.replace("{$serverpart}", s).replace("$", ""))
+        return cur_tile_url
+        
     def __repr__(self):
         return "<MapLayer: url:{}, min_zoom:{}, max_zoom:{}>".format(
             self.tile_url, self.min_zoom, self.max_zoom)
@@ -247,6 +262,8 @@ class MapSource(object):
                     map_layer.min_zoom = int(elem.text)
                 elif elem.tag == 'maxZoom':
                     map_layer.max_zoom = int(elem.text)
+                elif elem.tag == 'serverParts':
+                    map_layer.server_parts += str(elem.text).split()
         except ValueError:
             raise MapSourceException("minZoom/maxZoom must be an integer. ")
 

--- a/geos/server.py
+++ b/geos/server.py
@@ -44,7 +44,7 @@ def maps_json():
                     {
                         "min_zoom": layer.min_zoom,
                         "max_zoom": layer.max_zoom,
-                        "tile_url": layer.tile_url.replace("$", ""),
+                        "tile_url": layer.get_tile_urls,
                     } for layer in map_source.layers
                     ]
 

--- a/geos/static/custom.js
+++ b/geos/static/custom.js
@@ -313,7 +313,7 @@ function activateMap(mapSource) {
     $.each(mapSource.layers, function (i, tileLayer) {
         tmpLayer = new ol.layer.Tile({
             source: new ol.source.XYZ({
-                url: tileLayer.tile_url,
+                urls: tileLayer.tile_url,
                 crossOrigin: null,
                 minZoom: tileLayer.min_zoom,
                 maxZoom: tileLayer.max_zoom

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-certifi==2019.3.9
-Click==7.0
-Flask==1.0.3
-itsdangerous==1.1.0
-Jinja2==2.10.1
-lxml==4.3.3
-MarkupSafe==1.1.1
-Pillow==6.2.0
-Werkzeug==0.15.4

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 setup(
     name='geos',
-    version='0.2.2',
+    version='0.2.3',
     packages=find_packages(),
     description='Map server to view, measure and print maps in a web browser'
                 'and to display maps as an overlay in google earth.',
@@ -15,6 +15,9 @@ setup(
     install_requires=[
         'flask', 'lxml', 'pillow'
     ],
+    extras_require=dict(
+        test=['pytest']
+    ),
     classifiers=[],
     entry_points={
         'console_scripts': ['geos=geos.scripts.runserver:run_app'],


### PR DESCRIPTION
tested for kml overlay in GE and OpenLayers (/maps.json) in browser
```
<?xml version="1.0" encoding="UTF-8"?>
<customMapSource>
	<name><![CDATA[OpenTopoMap]]></name>
	<minZoom>5</minZoom>
	<maxZoom>20</maxZoom>
	<tileType>png</tileType>
	<tileUpdate>IfModifiedSince</tileUpdate>
	<ignoreErrors>true</ignoreErrors>
	<backgroundColor>#00000000</backgroundColor>
	<url><![CDATA[https://{$serverpart}.tile.opentopomap.org/{$z}/{$x}/{$y}.png]]></url>
	<serverParts>a b c</serverParts>
</customMapSource>
```