### PR TITLE
Accept any python version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM continuumio/miniconda3
 COPY . .
 RUN python setup.py install 
-RUN export GEOS_VERSION="$(python setup.py --version)" \
-    && ln -s /opt/conda/lib/python3.7/site-packages/geos-"$GEOS_VERSION"-py3.7.egg/geos /opt/conda/lib/python3.7/site-packages/geos
+RUN cd /opt/conda/lib/python*/site-packages && ln -s geos-*/geos geos


### PR DESCRIPTION
Avoid the hard-coded `python3.7` version and this error:

```
Step 4/4 : RUN export GEOS_VERSION="$(python setup.py --version)"     && ln -s /opt/conda/lib/python3.7/site-packages/geos-"$GEOS_VERSION"-py3.7.egg/geos /opt/conda/lib/python3.7/site-packages/geos
 ---> Running in 5a9c9d929409
ln: failed to create symbolic link '/opt/conda/lib/python3.7/site-packages/geos': No such file or directory
The command '/bin/sh -c export GEOS_VERSION="$(python setup.py --version)"     && ln -s /opt/conda/lib/python3.7/site-packages/geos-"$GEOS_VERSION"-py3.7.egg/geos /opt/conda/lib/python3.7/site-packages/geos' returned a non-zero code: 1
```