### PR TITLE
Update users.md

### DIFF
--- a/doc/users.md
+++ b/doc/users.md
@@ -13,7 +13,6 @@ pip install geos
 Alternatively, you can install _GEOS_ from the github sources:
 ```sh
 git clone https://github.com/grst/geos.git
-cd geos
 pip install -e geos
 ```
 


### PR DESCRIPTION
If you try and install using pip from within the geos directory, pip throws:
ERROR: file:///home/web/geos/geos does not appear to be a Python project: neither 'setup.py' nor 'pyproject.toml' found.
So the command to "cd geos" is wrong & should be removed.