### PR TITLE
Fixes Python 3.9 incompatability

### DIFF
--- a/geos/mapsource.py
+++ b/geos/mapsource.py
@@ -255,7 +255,7 @@ class MapSource(object):
         """
         map_layer = MapLayer()
         try:
-            for elem in xml_custom_map_source.getchildren():
+            for elem in xml_custom_map_source:
                 if elem.tag == 'url':
                     map_layer.tile_url = elem.text
                 elif elem.tag == 'minZoom':


### PR DESCRIPTION
Removes use of getchildren() call which is deprecated in Python3.9 per https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getchildren

Now uses iteration.

Resolves issue #42 